### PR TITLE
keybind is not working when open multiple buffers (nvchad)

### DIFF
--- a/autoload/tabby/inline_completion.vim
+++ b/autoload/tabby/inline_completion.vim
@@ -14,6 +14,7 @@ function! tabby#inline_completion#Setup()
     autocmd!
     autocmd User tabby_lsp_on_buffer_attached call tabby#inline_completion#Install()
   augroup end
+  autocmd BufNewFile,BufRead * call tabby#inline_completion#keybindings#Setup()
 endfunction
 
 function! tabby#inline_completion#Install()


### PR DESCRIPTION
I'm using nvchad, that realize the problem while open multiple buffers:
open nvim with first buffer opened:
<img width="548" alt="Screenshot 2024-12-30 at 14 46 33" src="https://github.com/user-attachments/assets/4f0fdf6a-3ef9-464f-b842-1a365afaf859" />
when open new buffer:
<img width="496" alt="Screenshot 2024-12-30 at 14 46 51" src="https://github.com/user-attachments/assets/38f16671-f6d9-46e1-bad5-dd06892f417e" />

After checking around I see that, the function `tabby#inline_completion#keybindings#Setup` is just initilized when open fisrt buffer.
```
function! tabby#inline_completion#Install()
  call tabby#inline_completion#events#Install()
  call tabby#inline_completion#keybindings#Setup()
  call tabby#inline_completion#virtual_text#Setup()
endfunction
```
sulution here is create an autocmd
```
function! tabby#inline_completion#Setup()
  augroup tabby_inline_completion_events
    autocmd!
    autocmd User tabby_lsp_on_buffer_attached call tabby#inline_completion#Install()
  augroup end
  autocmd BufNewFile,BufRead * call tabby#inline_completion#keybindings#Setup()
endfunction
```
Noted: I'm quite new in mua and nvim plugin, please help to review