### PR TITLE
Disabling tabby for filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Here is a table of all configuration variables that can be set when the Tabby pl
 | `g:tabby_inline_completion_keybinding_accept` | `"<Tab>"` | The keybinding to accept the inline completion |
 | `g:tabby_inline_completion_keybinding_trigger_or_dismiss` | `"<C-\>"` | The keybinding to trigger or dismiss the inline completion |
 | `g:tabby_inline_completion_insertion_leading_key` | `"\<C-R>\<C-O>="` | The leading key sequence to insert the inline completion text |
+| `g:tabby_disabled_filetypes` | `[]` | List of filetypes for which Tabby suggestions are disabled |
+| `g:tabby_disable_all_except_filetypes` | `[]` | List of filetypes to enable Tabby for; when non‑empty, all other filetypes are disabled |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Here is a table of all configuration variables that can be set when the Tabby pl
 | `g:tabby_inline_completion_keybinding_accept` | `"<Tab>"` | The keybinding to accept the inline completion |
 | `g:tabby_inline_completion_keybinding_trigger_or_dismiss` | `"<C-\>"` | The keybinding to trigger or dismiss the inline completion |
 | `g:tabby_inline_completion_insertion_leading_key` | `"\<C-R>\<C-O>="` | The leading key sequence to insert the inline completion text |
-| `g:tabby_disabled_filetypes` | `[]` | List of filetypes for which Tabby suggestions are disabled |
-| `g:tabby_disable_all_except_filetypes` | `[]` | List of filetypes to enable Tabby for; when non‑empty, all other filetypes are disabled |
+| `g:tabby_disabled_filetypes` | `[]` | List of filetypes for which Tabby suggestions are disabled (eg. ['markdown', 'toml'])|
+| `g:tabby_disable_all_except_filetypes` | `[]` | List of filetypes to enable Tabby for; when non‑empty, all other filetypes are disabled (eg. ['rust'])|
 
 ## Contributing
 

--- a/autoload/tabby/inline_completion/service.vim
+++ b/autoload/tabby/inline_completion/service.vim
@@ -43,14 +43,17 @@ function! tabby#inline_completion#service#Trigger(is_manually)
   if g:tabby_inline_completion_trigger != 'auto' && !a:is_manually
     return
   endif
+
   " Do not trigger for disabled filetypes
   if index(g:tabby_disabled_filetypes, &filetype) >= 0
     return
   endif
+
   " When "disable all except" list is non‑empty, only allow those filetypes
-  if len(g:tabby_disable_all_except_filetypes) > 0 && index(g:tabby_disable_all_except_filetypes, &filetype) < 0
+  if len(g:tabby_disable_all_except_filetypes) > 0 && index(g:tabby_disable_all_except_filetypes, &filetype) == -1
     return
   endif
+
   let params = s:CreateInlineCompletionContext(a:is_manually)
   let s:current_request_context = params
   let OnResponse = { result -> s:HandleCompletionResponse(params, result) }

--- a/autoload/tabby/inline_completion/service.vim
+++ b/autoload/tabby/inline_completion/service.vim
@@ -6,6 +6,14 @@ let g:autoloaded_tabby_inline_completion_service = 1
 let g:tabby_inline_completion_trigger = get(g:, 'tabby_inline_completion_trigger', 'auto')
 let g:tabby_inline_completion_insertion_leading_key = get(g:, 'tabby_inline_completion_insertion_leading_key', "\<C-R>\<C-O>=")
 
+" List of filetypes for which tabby suggestions are disabled.
+let g:tabby_disabled_filetypes = get(g:, 'tabby_disabled_filetypes', [])
+
+" List of filetypes for which tabby suggestions are enabled when the
+" "disable all except" mode is active. If non‑empty, all other filetypes are
+" automatically disabled.
+let g:tabby_disable_all_except_filetypes = get(g:, 'tabby_disable_all_except_filetypes', [])
+
 let s:current_request_context = {}
 let s:current_request_id = 0
 
@@ -33,6 +41,14 @@ function! tabby#inline_completion#service#Trigger(is_manually)
     call g:tabby_inline_completion_source.CancelRequest(s:current_request_id)
   endif
   if g:tabby_inline_completion_trigger != 'auto' && !a:is_manually
+    return
+  endif
+  " Do not trigger for disabled filetypes
+  if index(g:tabby_disabled_filetypes, &filetype) >= 0
+    return
+  endif
+  " When "disable all except" list is non‑empty, only allow those filetypes
+  if len(g:tabby_disable_all_except_filetypes) > 0 && index(g:tabby_disable_all_except_filetypes, &filetype) < 0
     return
   endif
   let params = s:CreateInlineCompletionContext(a:is_manually)


### PR DESCRIPTION
closes #38

This PR adds two new options: 
tabby_disabled_filetypes -> disables the provided filetypes 
tabby_disable_all_except_filetypes -> disables tabby for all EXCEPT the provided filetypes

I find this feature useful and am already using it